### PR TITLE
Specified maven-hpi-plugin version 3.0.3 to resolve issues with Java 7.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,12 @@
               <artifactId>maven-dependency-plugin</artifactId>
               <version>2.1</version>
           </plugin>
+          <plugin>
+            <groupId>org.eclipse.hudson.tools</groupId>
+            <artifactId>maven-hpi-plugin</artifactId>
+            <!-- Version 3.0.3 should resolve failures with Java 7. -->
+            <version>3.0.3</version>
+          </plugin>
       </plugins>
   </build>
 


### PR DESCRIPTION
I need to update maven-hpi-plugin so that I can use Java 7 or 8.
