### PR TITLE
Specified the latest cobertura-maven-plugin version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
          <plugin>
               <groupId>org.codehaus.mojo</groupId>
               <artifactId>cobertura-maven-plugin</artifactId>
+              <version>2.7</version>
               <configuration>
                 <instrumentation>
                     <excludes>


### PR DESCRIPTION
Filled the unspecified version of cobertura-maven-plugin to resolve a Maven warning. It passed all the self-tests.
